### PR TITLE
remove `finitediff` from `ndarrayl` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ argmin_testfunctions = "0.1.1"
 
 [features]
 default = []
-ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand", "finitediff/ndarray"]
+ndarrayl = ["ndarray", "ndarray-linalg", "ndarray-rand"]
 visualizer = ["gnuplot"]
 
 [badges]


### PR DESCRIPTION
Without this change, `ndarrayl` feature not working.

`finitediff` is not used in code under the `ndarray` feature